### PR TITLE
remove pin on jsonpath-ng and fix issue

### DIFF
--- a/localstack_snapshot/snapshots/prototype.py
+++ b/localstack_snapshot/snapshots/prototype.py
@@ -339,7 +339,7 @@ class SnapshotSession:
 
         def build_full_path_nodes(field_match: DatumInContext):
             """Traverse the matched Datum to build the path field by field"""
-            full_path_nodes = [str(field_match.path)]
+            full_path_nodes = [str(field_match.path).replace("'", "")]
             next_node = field_match
             while next_node.context is not None:
                 full_path_nodes.append(str(next_node.context.path))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 version = "0.1.0"
 description = "Extracted snapshot testing lib for LocalStack"
 dependencies = [
-    "jsonpath-ng==1.5.3",  # TODO: resolve this pin
+    "jsonpath-ng>1.6",
     "deepdiff",
     "botocore",
 ]


### PR DESCRIPTION
We had to pin `jsonpath-ng` to 1.5.3 following an update from the library. The following line from the change log is responsible:
> - Enclose field names containing literals in quotes

Basically, the matched path was returned with quotes when accessing from `match.full_path` or `match.path`, which lead to issue in matching. 
We manually remove the `'` from the field in order to have the same behavior as before. 

Example from `test_dot_in_skip_verification_path`:
Skipped paths: `["$..aab", "$..b.'a.aa'"]`
Matching the fields for `"$..b.'a.aa'"`
Before the fix: 
- `1.5.3` / match full path = `key_a.b.a.aa` / return value from `build_full_path_nodes` = `["key_a", "b", "a.aa"]`
- `>1.6` / match full path = `key_a.b.'a.aa'` / return value from `build_full_path_nodes` = `["key_a", "b", "'a.aa'"]`

I believe we now could also use a regex instead of the whole `build_full_path_nodes`, which would basically split on `.` not being enclosed in `'`, but my regex knowledge is lacking 😬 

This simple fix will allow us to unpin for now. 