### PR TITLE
Improve error message for reference replacement using non-iterable types

### DIFF
--- a/localstack_snapshot/snapshots/transformer.py
+++ b/localstack_snapshot/snapshots/transformer.py
@@ -49,18 +49,19 @@ def _register_serialized_reference_replacement(
 ):
     # Provide a better error message for the TypeError if the reference value is not iterable (e.g., float)
     # Example: `TypeError: argument of type 'float' is not iterable`
-    # The snapshot library currently does not support reference replacements for non-string types.
-    try:
-        if '"' in reference_value:
-            reference_value = reference_value.replace('"', '\\"')
-    except TypeError as e:
+    # Using a list would throw an AttributeError because `.replace` is not applicable.
+    # The snapshot library currently only supports strings for reference replacements
+    if not isinstance(reference_value, str):
         message = (
-            f"Reference value {reference_value} of type {type(reference_value)} is not iterable."
+            f"The reference value {reference_value} of type {type(reference_value)} is not a string."
             f" Consider using `reference_replacement=False` in your transformer"
-            f" for the replacement {replacement}."
+            f" for the replacement {replacement} because reference replacements are only supported for strings."
         )
-        SNAPSHOT_LOGGER.error(message, exc_info=True)
-        raise TransformerException(message) from e
+        SNAPSHOT_LOGGER.error(message)
+        raise TransformerException(message)
+
+    if '"' in reference_value:
+        reference_value = reference_value.replace('"', '\\"')
 
     cache = transform_context._cache.setdefault("regexcache", set())
     cache_key = reference_value


### PR DESCRIPTION
## Motivation

Using a `key_value` transformer for non-iterable types (e.g., floats) raises a `TypeError` within the `transformer.py` utility. This happens by default unless reference replacement is actively disabled using `reference_replacement=False`. The error message is unclear and does not suggest any actions to mitigate the problem.

## Changes

* Introduce a transformer exception with a clearer actionable error message. The error message suggests disabling reference replacement and mentions the specific replacement value. For example:
   > localstack_snapshot.snapshots.transformer.TransformerException: The reference value 1710334764.901 of type <class 'float'> is not a string. Consider using `reference_replacement=False` in your transformer for the replacement approximate-arrival-timestamp because reference replacements are only supported for strings.

### Exception Before 

> TypeError: argument of type 'float' is not iterable

```python
transform_context = <localstack_snapshot.snapshots.transformer.TransformContext object at 0x314e1fc90>

    def _register_serialized_reference_replacement(
        transform_context: TransformContext, *, reference_value: str, replacement: str
    ):
>       if '"' in reference_value:
E       TypeError: argument of type 'float' is not iterable

../../../../../localstack-snapshot/localstack_snapshot/snapshots/transformer.py:46: TypeError
```

### After

> localstack_snapshot.snapshots.transformer.TransformerException: The reference value 1710334764.901 of type <class 'float'> is not a string. Consider using `reference_replacement=False` in your transformer for the replacement approximate-arrival-timestamp because reference replacements are only supported for strings.

```python
transform_context = <localstack_snapshot.snapshots.transformer.TransformContext object at 0x320c439d0>

    def _register_serialized_reference_replacement(
        transform_context: TransformContext, *, reference_value: str, replacement: str
    ):
        # Provide a better error message for the TypeError if the reference value is not iterable (e.g., float)
        # Example: `TypeError: argument of type 'float' is not iterable`
        # Using a list would throw an AttributeError because `.replace` is not applicable.
        # The snapshot library currently only supports strings for reference replacements
        if not isinstance(reference_value, str):
            message = (
                f"The reference value {reference_value} of type {type(reference_value)} is not a string."
                f" Consider using `reference_replacement=False` in your transformer"
                f" for the replacement {replacement} because reference replacements are only supported for strings."
            )
            SNAPSHOT_LOGGER.error(message)
>           raise TransformerException(message)
E           localstack_snapshot.snapshots.transformer.TransformerException: The reference value 1710334764.901 of type <class 'float'> is not a string. Consider using `reference_replacement=False` in your transformer for the replacement approximate-arrival-timestamp because reference replacements are only supported for strings.

../../../../../localstack-snapshot/localstack_snapshot/snapshots/transformer.py:61: TransformerException
```

## Testing

1. Install the latest `localstack-snapshot` library into your LocalStack venv: `pip install -e ../localstack-snapshot[dev]`
2. In the ext test `tests.aws.services.pipes.test_pipes.TestPipes.test_kinesis_pipe`, enable reference replacement for `approximateArrivalTimestamp`:
   > snapshot.add_transformer(
   >         snapshot.transform.key_value("approximateArrivalTimestamp", reference_replacement=True)
   >     )
3. Run the test 

## Alternative Considerations

TLDR: Supporting non-iterable types for reference replacement would require further changes and testing in the snapshot library.

* Only apply quote escaping if the reference value is a string such as `if isinstance(reference_value, str) and '"' in reference_value:`
  * Leads to exceptions in other parts of the snapshot library because it is not designed to handle non-iterable types for reference replacements
* Convert non-string reference values to strings such as `reference_value = str(reference_value)`
  * Leads to KeyError and requires other changes

## Follow-up

- [ ] Release new version
- [ ] Update pinned dependency in LocalStack
