### PR TITLE
API: add snapshot.match_object()

### DIFF
--- a/localstack_snapshot/snapshots/prototype.py
+++ b/localstack_snapshot/snapshots/prototype.py
@@ -164,6 +164,20 @@ class SnapshotSession:
     def _update(self, key: str, obj_state: dict) -> None:
         self.observed_state[key] = obj_state
 
+    def match_object(self, key: str, obj: object) -> None:
+        def _convert_object_to_dict(obj_):
+            if isinstance(obj_, dict):
+                for key in list(obj_.keys()):
+                    obj_[key] = _convert_object_to_dict(obj_[key])
+            elif isinstance(obj_, list):
+                for idx, val in enumerate(obj_):
+                    obj_[idx] = _convert_object_to_dict(val)
+            elif hasattr(obj_, "__dict__"):
+                return _convert_object_to_dict(obj_.__dict__)
+            return obj_
+
+        return self.match(key, _convert_object_to_dict(obj))
+
     def match(self, key: str, obj: dict) -> None:
         if key in self.called_keys:
             raise Exception(

--- a/localstack_snapshot/snapshots/prototype.py
+++ b/localstack_snapshot/snapshots/prototype.py
@@ -168,7 +168,10 @@ class SnapshotSession:
         def _convert_object_to_dict(obj_):
             if isinstance(obj_, dict):
                 for key in list(obj_.keys()):
-                    obj_[key] = _convert_object_to_dict(obj_[key])
+                    if key.startswith("_"):
+                        del obj_[key]
+                    else:
+                        obj_[key] = _convert_object_to_dict(obj_[key])
             elif isinstance(obj_, list):
                 for idx, val in enumerate(obj_):
                     obj_[idx] = _convert_object_to_dict(val)

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -56,6 +56,17 @@ class TestSnapshotManager:
         sm.match_object("key_a", CustomObject(name="myname", nested=True))
         sm._assert_all()
 
+    def test_match_object_ignore_private_values(self):
+        class CustomObject:
+            def __init__(self, name):
+                self.name = name
+                self._internal = "n/a"
+
+        sm = SnapshotSession(scope_key="A", verify=True, base_file_path="", update=False)
+        sm.recorded_state = {"key_a": {"name": "myname"}}
+        sm.match_object("key_a", CustomObject(name="myname"))
+        sm._assert_all()
+
     def test_match_object_change(self):
         class CustomObject:
             def __init__(self, name):


### PR DESCRIPTION
The existing `match()` function expects a dictionary. But when writing tests for a certain other SDK, it returns objects instead of dictionaries. So it would be nice to have an option to serialize random objects as well, without having to care about the exact format.

An alternative implementation to get the same functionality would be to add this to the `match()` function:
```
def match(self, key: str, obj: object) -> None:
    # Transform incoming object to a dictionary
    obj: dict = _convert_object_to_dict(obj)

    ...
```

I have no preference either way - I just picked the least invasive change, to avoid breaking the existing functionality in some unknown way.