### PR TITLE
Remove botocore dependency by transform any IO-stream

### DIFF
--- a/localstack_snapshot/snapshots/prototype.py
+++ b/localstack_snapshot/snapshots/prototype.py
@@ -1,3 +1,4 @@
+import io
 import json
 import logging
 import os
@@ -7,7 +8,6 @@ from pathlib import Path
 from re import Pattern
 from typing import Dict, List, Optional
 
-from botocore.response import StreamingBody
 from deepdiff import DeepDiff
 from jsonpath_ng import DatumInContext
 from jsonpath_ng.ext import parse
@@ -260,11 +260,10 @@ class SnapshotSession:
     def _transform_dict_to_parseable_values(self, original):
         """recursively goes through dict and tries to resolve values to strings (& parse them as json if possible)"""
         for k, v in original.items():
-            if isinstance(v, StreamingBody):
+            if isinstance(v, io.IOBase):
                 # update v for json parsing below
-                original[k] = v = v.read().decode(
-                    "utf-8"
-                )  # TODO: patch boto client so this doesn't break any further read() calls
+                # TODO: patch boto client so this doesn't break any further read() calls
+                original[k] = v = v.read().decode("utf-8")
             if isinstance(v, list) and v:
                 for item in v:
                     if isinstance(item, dict):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ description = "Extracted snapshot testing lib for LocalStack"
 dependencies = [
     "jsonpath-ng>1.6",
     "deepdiff",
-    "botocore",
 ]
 requires-python = ">=3.10"
 license = {file = "LICENSE"}

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -1,3 +1,5 @@
+import io
+
 import pytest
 
 from localstack_snapshot.snapshots import SnapshotSession
@@ -19,6 +21,12 @@ class TestSnapshotManager:
         with pytest.raises(Exception) as ctx:
             sm._assert_all()
         ctx.match("Parity snapshot failed")
+
+    def test_diff_with_io_stream(self):
+        sm = SnapshotSession(scope_key="A", verify=True, base_file_path="", update=False)
+        sm.recorded_state = {"key_a": {"a": "data"}}
+        sm.match("key_a", {"a": io.BytesIO(b"data")})
+        sm._assert_all()
 
     def test_multiple_assertmatch_with_same_key_fail(self):
         sm = SnapshotSession(scope_key="A", verify=True, base_file_path="", update=False)


### PR DESCRIPTION
This reduces the footprint for any projects that use this library - they shouldn't have to have `botocore` as a dependency.

Note that I went with the `io.IOBase` as a replacement, simply because that's the immediate parent of `botocore.response.StreamingBody`.

However: a class that implements `IOBase` does not **need** to have a `read` method implemented . From the docs:

> Even though [IOBase](https://docs.python.org/3/library/io.html#io.IOBase) does not declare read() or write() because their signatures will vary, implementations and clients should consider those methods part of the interface.

Considering all known IOstreams  (`StringIO`, `BytesIO`, etc) do have the `read` implemented, I think this is an edge case though, and not something we should worry about.