### PR TITLE
Introduce a TextTransformer to replace strings with special chars

### DIFF
--- a/localstack_snapshot/snapshots/transformer.py
+++ b/localstack_snapshot/snapshots/transformer.py
@@ -344,3 +344,19 @@ class TimestampTransformer:
 
     def _transform_list(self, input_data: list, ctx: TransformContext = None) -> list:
         return [self._transform(e, ctx=ctx) for e in input_data]
+
+
+class TextTransformer:
+    def __init__(self, text: str, replacement: str):
+        self.text = text
+        self.replacement = replacement
+
+    def transform(self, input_data: dict, *, ctx: TransformContext) -> dict:
+        def replace_val(s):
+            return s.replace(self.text, self.replacement)
+
+        ctx.register_serialized_replacement(replace_val)
+        SNAPSHOT_LOGGER.debug(
+            f"Registering text pattern '{self.text}' in snapshot with '{self.replacement}'"
+        )
+        return input_data

--- a/localstack_snapshot/snapshots/transformer_utility.py
+++ b/localstack_snapshot/snapshots/transformer_utility.py
@@ -5,6 +5,7 @@ from localstack_snapshot.snapshots.transformer import (
     JsonpathTransformer,
     KeyValueBasedTransformer,
     RegexTransformer,
+    TextTransformer,
 )
 
 
@@ -67,3 +68,16 @@ class TransformerUtility:
         :return: RegexTransformer
         """
         return RegexTransformer(regex, replacement)
+
+    @staticmethod
+    def text(text: str, replacement: str):
+        """Creates a new TextTransformer. All occurrences in the string-converted dict will be replaced.
+
+        Useful if the text contains special characters that would confuse the RegexTransformer, like '+' or '('.
+
+        :param text: the text that should be replaced
+        :param replacement: the value which will replace the original value.
+
+        :return: TextTransformer
+        """
+        return TextTransformer(text, replacement)

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -211,6 +211,31 @@ class TestTransformer:
         output = transformer.transform(input, ctx=ctx)
         assert output == expected
 
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "a+b",
+            "question?",
+            "amount: $4.00",
+            "emoji: ^^",
+            "sentence.",
+            "others (like so)",
+            "special {char}",
+        ],
+    )
+    def test_text(self, value):
+        input = {"key": f"some {value} with more text"}
+
+        expected = {"key": "some <value> with more text"}
+
+        transformer = TransformerUtility.text(value, "<value>")
+
+        ctx = TransformContext()
+        output = transformer.transform(json.dumps(input), ctx=ctx)
+        for sr in ctx.serialized_replacements:
+            output = sr(output)
+        assert json.loads(output) == expected
+
 
 class TestTimestampTransformer:
     def test_generic_timestamp_transformer(self):


### PR DESCRIPTION
The regex transformer works in 99% of the cases, but I ran into some problems when trying to match a base64 representation like `asdf+qwer=`.

The regex transformer assumes the `+` is a special character, so it will not match the exact value. Hence the `TextTransformer, that just transforms the entire string as-is.