### PR TITLE
Add transformer for JSON strings

### DIFF
--- a/localstack_snapshot/snapshots/prototype.py
+++ b/localstack_snapshot/snapshots/prototype.py
@@ -271,16 +271,10 @@ class SnapshotSession:
             if isinstance(v, Dict):
                 self._transform_dict_to_parseable_values(v)
 
-            if isinstance(v, str) and (v.startswith("{") or v.startswith("[")):
+            if isinstance(v, str) and v.startswith("{"):
                 try:
                     json_value = json.loads(v)
                     original[k] = json_value
-                    if isinstance(json_value, list) and json_value:
-                        for item in json_value:
-                            if isinstance(item, dict):
-                                self._transform_dict_to_parseable_values(item)
-                    if isinstance(json_value, Dict):
-                        self._transform_dict_to_parseable_values(json_value)
                 except JSONDecodeError:
                     pass  # parsing error can be ignored
 

--- a/localstack_snapshot/snapshots/prototype.py
+++ b/localstack_snapshot/snapshots/prototype.py
@@ -272,6 +272,8 @@ class SnapshotSession:
                 self._transform_dict_to_parseable_values(v)
 
             if isinstance(v, str) and v.startswith("{"):
+                # Doesn't handle JSON arrays and nested JSON strings. See JsonStringTransformer.
+                # TODO for the major release consider having JSON parsing in one place only: either here or in JsonStringTransformer
                 try:
                     json_value = json.loads(v)
                     original[k] = json_value

--- a/localstack_snapshot/snapshots/prototype.py
+++ b/localstack_snapshot/snapshots/prototype.py
@@ -271,10 +271,16 @@ class SnapshotSession:
             if isinstance(v, Dict):
                 self._transform_dict_to_parseable_values(v)
 
-            if isinstance(v, str) and v.startswith("{"):
+            if isinstance(v, str) and (v.startswith("{") or v.startswith("[")):
                 try:
                     json_value = json.loads(v)
                     original[k] = json_value
+                    if isinstance(json_value, list) and json_value:
+                        for item in json_value:
+                            if isinstance(item, dict):
+                                self._transform_dict_to_parseable_values(item)
+                    if isinstance(json_value, Dict):
+                        self._transform_dict_to_parseable_values(json_value)
                 except JSONDecodeError:
                     pass  # parsing error can be ignored
 

--- a/localstack_snapshot/snapshots/transformer.py
+++ b/localstack_snapshot/snapshots/transformer.py
@@ -415,7 +415,7 @@ class JsonStringTransformer:
         if isinstance(input_data, dict):
             for k, v in input_data.items():
                 input_data[k] = self._transform_nested(v)
-        if isinstance(input_data, str) and input_data.startswith(("{", "[")):
+        if isinstance(input_data, str) and input_data.strip().startswith(("{", "[")):
             try:
                 json_value = json.loads(input_data)
                 input_data = self._transform_nested(json_value)

--- a/localstack_snapshot/snapshots/transformer.py
+++ b/localstack_snapshot/snapshots/transformer.py
@@ -393,8 +393,8 @@ class JsonStringTransformer:
                     json_value = json.loads(v)
                     input_data[k] = self._transform_nested(json_value)
                 except JSONDecodeError:
-                    SNAPSHOT_LOGGER.warning(
-                        f'The value mapped to "{k}" key is not a valid JSON string and won\'t be transformed'
+                    SNAPSHOT_LOGGER.exception(
+                        f'Value mapped to "{k}" key is not a valid JSON string and won\'t be transformed. Value: {v}'
                     )
             else:
                 input_data[k] = self._transform(v, ctx=ctx)
@@ -420,5 +420,7 @@ class JsonStringTransformer:
                 json_value = json.loads(input_data)
                 input_data = self._transform_nested(json_value)
             except JSONDecodeError:
-                pass  # parsing nested JSON strings is a best effort rather than requirement, so no error message here
+                SNAPSHOT_LOGGER.debug(
+                    f"The value is not a valid JSON string and won't be transformed. The value: {input_data}"
+                )
         return input_data

--- a/localstack_snapshot/snapshots/transformer.py
+++ b/localstack_snapshot/snapshots/transformer.py
@@ -376,9 +376,23 @@ class JsonStringTransformer:
                 if isinstance(v, str):
                     try:
                         json_value = json.loads(v)
-                        input_data[k] = json_value
+                        input_data[k] = self._transform_nested(json_value)
                     except JSONDecodeError:
                         SNAPSHOT_LOGGER.warning(
                             f'The value mapped to "{k}" key is not a valid JSON string and won\'t be transformed'
                         )
+        return input_data
+
+    def _transform_nested(self, input_data: Any):
+        if isinstance(input_data, list):
+            input_data = [self._transform_nested(item) for item in input_data]
+        if isinstance(input_data, dict):
+            for k, v in input_data.items():
+                input_data[k] = self._transform_nested(v)
+        if isinstance(input_data, str) and input_data.startswith(("{", "[")):
+            try:
+                json_value = json.loads(input_data)
+                input_data = self._transform_nested(json_value)
+            except JSONDecodeError:
+                pass  # parsing nested JSON strings is a best effort rather than requirement, so no error message here
         return input_data

--- a/localstack_snapshot/snapshots/transformer.py
+++ b/localstack_snapshot/snapshots/transformer.py
@@ -365,6 +365,11 @@ class TextTransformer:
 
 
 class JsonStringTransformer:
+    """
+    Parses JSON string at key.
+    Additionally, attempts to parse any JSON strings inside the parsed JSON
+    """
+
     key: str
 
     def __init__(self, key: str):
@@ -398,11 +403,12 @@ class JsonStringTransformer:
     def _transform_list(self, input_data: list, ctx: TransformContext = None) -> list:
         return [self._transform(item, ctx=ctx) for item in input_data]
 
-    def _transform_nested(self, input_data: Any):
+    def _transform_nested(self, input_data: Any) -> Any:
         """
-        Attempts to parse any additional JSON strings inside parsed JSON
-        :param input_data:
-        :return:
+        Separate method from the main `_transform_dict` one because
+        it checks every string while the main one attempts to load at specified key only.
+        This one is implicit, best-effort attempt,
+        while the main one is explicit about at which key transform should happen
         """
         if isinstance(input_data, list):
             input_data = [self._transform_nested(item) for item in input_data]

--- a/localstack_snapshot/snapshots/transformer.py
+++ b/localstack_snapshot/snapshots/transformer.py
@@ -370,20 +370,40 @@ class JsonStringTransformer:
     def __init__(self, key: str):
         self.key = key
 
-    def transform(self, input_data: dict, *, ctx: TransformContext) -> dict:
-        for k, v in input_data.items():
-            if k == self.key:
-                if isinstance(v, str):
-                    try:
-                        json_value = json.loads(v)
-                        input_data[k] = self._transform_nested(json_value)
-                    except JSONDecodeError:
-                        SNAPSHOT_LOGGER.warning(
-                            f'The value mapped to "{k}" key is not a valid JSON string and won\'t be transformed'
-                        )
+    def transform(self, input_data: dict, *, ctx: TransformContext = None) -> dict:
+        return self._transform_dict(input_data, ctx=ctx)
+
+    def _transform(self, input_data: Any, ctx: TransformContext = None) -> Any:
+        if isinstance(input_data, dict):
+            return self._transform_dict(input_data, ctx=ctx)
+        elif isinstance(input_data, list):
+            return self._transform_list(input_data, ctx=ctx)
         return input_data
 
+    def _transform_dict(self, input_data: dict, ctx: TransformContext = None) -> dict:
+        for k, v in input_data.items():
+            if k == self.key and isinstance(v, str):
+                try:
+                    SNAPSHOT_LOGGER.debug(f"Replacing string value of {k} with parsed JSON")
+                    json_value = json.loads(v)
+                    input_data[k] = self._transform_nested(json_value)
+                except JSONDecodeError:
+                    SNAPSHOT_LOGGER.warning(
+                        f'The value mapped to "{k}" key is not a valid JSON string and won\'t be transformed'
+                    )
+            else:
+                input_data[k] = self._transform(v, ctx=ctx)
+        return input_data
+
+    def _transform_list(self, input_data: list, ctx: TransformContext = None) -> list:
+        return [self._transform(item, ctx=ctx) for item in input_data]
+
     def _transform_nested(self, input_data: Any):
+        """
+        Attempts to parse any additional JSON strings inside parsed JSON
+        :param input_data:
+        :return:
+        """
         if isinstance(input_data, list):
             input_data = [self._transform_nested(item) for item in input_data]
         if isinstance(input_data, dict):

--- a/localstack_snapshot/snapshots/transformer.py
+++ b/localstack_snapshot/snapshots/transformer.py
@@ -360,3 +360,13 @@ class TextTransformer:
             f"Registering text pattern '{self.text}' in snapshot with '{self.replacement}'"
         )
         return input_data
+
+
+class JsonStringTransformer:
+    key: str
+
+    def __init__(self, key: str):
+        self.key = key
+
+    def transform(self, input_data: dict, *, ctx: TransformContext) -> dict:
+        return input_data

--- a/localstack_snapshot/snapshots/transformer.py
+++ b/localstack_snapshot/snapshots/transformer.py
@@ -1,8 +1,10 @@
 import copy
+import json
 import logging
 import os
 import re
 from datetime import datetime
+from json import JSONDecodeError
 from re import Pattern
 from typing import Any, Callable, Optional, Protocol
 
@@ -369,4 +371,14 @@ class JsonStringTransformer:
         self.key = key
 
     def transform(self, input_data: dict, *, ctx: TransformContext) -> dict:
+        for k, v in input_data.items():
+            if k == self.key:
+                if isinstance(v, str):
+                    try:
+                        json_value = json.loads(v)
+                        input_data[k] = json_value
+                    except JSONDecodeError:
+                        SNAPSHOT_LOGGER.warning(
+                            f'The value mapped to "{k}" key is not a valid JSON string and won\'t be transformed'
+                        )
         return input_data

--- a/localstack_snapshot/snapshots/transformer_utility.py
+++ b/localstack_snapshot/snapshots/transformer_utility.py
@@ -1,10 +1,12 @@
 from re import Pattern
-from typing import Optional
+from typing import Any, Callable, Optional
 
 from localstack_snapshot.snapshots.transformer import (
     JsonpathTransformer,
+    JsonStringTransformer,
     KeyValueBasedTransformer,
     RegexTransformer,
+    SortingTransformer,
     TextTransformer,
 )
 
@@ -81,3 +83,27 @@ class TransformerUtility:
         :return: TextTransformer
         """
         return TextTransformer(text, replacement)
+
+    @staticmethod
+    def json_string(key: str) -> JsonStringTransformer:
+        """Creates a new JsonStringTransformer. If there is a valid JSON text string at specified key
+        it will be loaded as a regular object or array.
+
+        :param key: key at which JSON string is expected
+
+        :return: JsonStringTransformer
+        """
+        return JsonStringTransformer(key)
+
+    @staticmethod
+    def sorting(key: str, sorting_fn: Optional[Callable[[...], Any]]) -> SortingTransformer:
+        """Creates a new SortingTransformer.
+
+        Sorts a list at `key` with the given `sorting_fn` (argument for `sorted(list, key=sorting_fn)`)
+
+        :param key: key at which the list to sort is expected
+        :param sorting_fn: sorting function
+
+        :return: SortingTransformer
+        """
+        return SortingTransformer(key, sorting_fn)

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -267,6 +267,18 @@ class TestTransformer:
 
         assert output == expected
 
+    def test_json_string_in_a_nested_key(self):
+        key = "nested-key-in-an-object-hidden-inside-a-list"
+        input_data = {"top-level-key": [{key: '{"a": "b"}'}]}
+        expected = {"top-level-key": [{key: {"a": "b"}}]}
+
+        transformer = JsonStringTransformer(key)
+
+        ctx = TransformContext()
+        output = transformer.transform(input_data, ctx=ctx)
+
+        assert output == expected
+
 
 class TestTimestampTransformer:
     def test_generic_timestamp_transformer(self):

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -4,6 +4,7 @@ import json
 import pytest
 
 from localstack_snapshot.snapshots.transformer import (
+    JsonStringTransformer,
     SortingTransformer,
     TimestampTransformer,
     TransformContext,
@@ -235,6 +236,18 @@ class TestTransformer:
         for sr in ctx.serialized_replacements:
             output = sr(output)
         assert json.loads(output) == expected
+
+    def test_json_string(self):
+        key = "key"
+        input = {key: '{"a":"b"}'}
+        expected = {key: {"a": "b"}}
+
+        transformer = JsonStringTransformer(key)
+
+        ctx = TransformContext()
+        output = transformer.transform(input, ctx=ctx)
+
+        assert output == expected
 
 
 class TestTimestampTransformer:

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -241,10 +241,16 @@ class TestTransformer:
         "input_value,transformed_value",
         [
             pytest.param('{"a": "b"}', {"a": "b"}, id="simple_json_object"),
-            pytest.param('{\n    "a": "b"\n}', {"a": "b"}, id="formatted_json_object"),
+            pytest.param('{\n  "a": "b"\n}', {"a": "b"}, id="formatted_json_object"),
+            pytest.param('\n  {"a": "b"}', {"a": "b"}, id="json_with_whitespaces"),
             pytest.param('{"a": 42}malformed', '{"a": 42}malformed', id="malformed_json"),
             pytest.param('["a", "b"]', ["a", "b"], id="simple_json_list"),
             pytest.param('{"a": "{\\"b\\":42}"}', {"a": {"b": 42}}, id="nested_json_object"),
+            pytest.param(
+                '{"a": "\\n  {\\n  \\"b\\":42}"}',
+                {"a": {"b": 42}},
+                id="nested_formatted_json_object_with_whitespaces",
+            ),
             pytest.param(
                 '{"a": "[{\\"b\\":\\"c\\"}]"}', {"a": [{"b": "c"}]}, id="nested_json_list"
             ),

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -237,15 +237,33 @@ class TestTransformer:
             output = sr(output)
         assert json.loads(output) == expected
 
-    def test_json_string(self):
+    @pytest.mark.parametrize(
+        "input_value,transformed_value",
+        [
+            pytest.param('{"a": "b"}', {"a": "b"}, id="simple_json_object"),
+            pytest.param('{\n    "a": "b"\n}', {"a": "b"}, id="formatted_json_object"),
+            pytest.param('{"a": 42}malformed', '{"a": 42}malformed', id="malformed_json"),
+            pytest.param('["a", "b"]', ["a", "b"], id="simple_json_list"),
+            pytest.param('{"a": "{\\"b\\":42}"}', {"a": {"b": 42}}, id="nested_json_object"),
+            pytest.param(
+                '{"a": "[{\\"b\\":\\"c\\"}]"}', {"a": [{"b": "c"}]}, id="nested_json_list"
+            ),
+            pytest.param(
+                '{"a": "{\\"b\\":42malformed}"}',
+                {"a": '{"b":42malformed}'},
+                id="malformed_nested_json",
+            ),
+        ],
+    )
+    def test_json_string(self, input_value, transformed_value):
         key = "key"
-        input = {key: '{"a":"b"}'}
-        expected = {key: {"a": "b"}}
+        input_data = {key: input_value}
+        expected = {key: transformed_value}
 
         transformer = JsonStringTransformer(key)
 
         ctx = TransformContext()
-        output = transformer.transform(input, ctx=ctx)
+        output = transformer.transform(input_data, ctx=ctx)
 
         assert output == expected
 


### PR DESCRIPTION
### Motivation

Some services response contains JSON strings within JSON strings, e.g. Cloudwatch Logs for EventBridge Pipes events.

We do have [first level JSON strings parsed](https://github.com/localstack/localstack-snapshot/blob/302c9937a16a607bf93b24aaa50b069f0ec0d9e6/localstack_snapshot/snapshots/prototype.py#L274) but we don't go recursively into parsed JSONs. This leads to the need of extracting and parsing such payloads separately in the test because otherwise only regex transformers can be applied to such string. Ideally, snapshot library should take care of this. See corresponding [discussion](https://github.com/localstack/localstack-ext/pull/3956#discussion_r1928467194) (thanks @gregfurman for inspiration!).

### Changes

Starting to parse nested JSONs in common transformation flow is a breaking change for existing recorded snapshots. This PR proposes non-breaking approach by introducing a separate transformer that can be applied on demand. This draft shows a usage example: https://github.com/localstack/localstack-ext/pull/3971