### PR TITLE
Add configuration options to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ To install the python and other developer requirements into a venv run:
 There's a few env vars that can be used with this project:
 
 * `TEST_TARGET`: Set to `AWS_CLOUD` to use an externally-deployed instance when running tests.
-* `SNAPSHOT_LEGACY_REPORT`: By default set to `0`. Can be set to `1`.
-* `SNAPSHOT_UDPATE`: By default set to `0`. Can be set to `1`.
-* `SNAPSHOT_RAW`: By default set to `0`. Can be set to `1`.
+* `SNAPSHOT_LEGACY_REPORT`: By default set to `0`. Can be set to `1`. This enables the legacy reporting output style.
+* `SNAPSHOT_UDPATE`: By default set to `0`. Can be set to `1`. This enables updating the snapshot file rather than comparing with its contents.
+* `SNAPSHOT_RAW`: By default set to `0`. Can be set to `1`. This outputs an additional snapshot file which contains the untransformed values.
 
 ## Format code
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To install the python and other developer requirements into a venv run:
 
     make install
 
-#### Usable env vars
+### Configuration options
 
 There's a few env vars that can be used with this project:
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ To install the python and other developer requirements into a venv run:
 There's a few env vars that can be used with this project:
 
 * `TEST_TARGET`: Set to `AWS_CLOUD` to use an externally-deployed instance when running tests.
-* `TEST_FORCE_SNAPSHOT_SKIP_VERIFY`: Set to `1` to force applying the snapshot filters regardless of what `TEST_TARGET` is set to.
 * `SNAPSHOT_LEGACY_REPORT`: By default set to `0`. Can be set to `1`.
 * `SNAPSHOT_UDPATE`: By default set to `0`. Can be set to `1`.
 * `SNAPSHOT_RAW`: By default set to `0`. Can be set to `1`.

--- a/README.md
+++ b/README.md
@@ -8,9 +8,19 @@ This project is in a very early stage and will be both restructured and renamed.
 
 ## Quickstart
 
-to install the python and other developer requirements into a venv run:
+To install the python and other developer requirements into a venv run:
 
     make install
+
+#### Usable env vars
+
+There's a few env vars that can be used with this project:
+
+* `TEST_TARGET`: Set to `AWS_CLOUD` to use an externally-deployed instance when running tests.
+* `TEST_FORCE_SNAPSHOT_SKIP_VERIFY`: Set to `1` to force applying the snapshot filters regardless of what `TEST_TARGET` is set to.
+* `SNAPSHOT_LEGACY_REPORT`: By default set to `0`. Can be set to `1`.
+* `SNAPSHOT_UDPATE`: By default set to `0`. Can be set to `1`.
+* `SNAPSHOT_RAW`: By default set to `0`. Can be set to `1`.
 
 ## Format code
 

--- a/localstack_snapshot/pytest/snapshot.py
+++ b/localstack_snapshot/pytest/snapshot.py
@@ -20,7 +20,6 @@ def is_aws():
     return os.environ.get("TEST_TARGET", "") == "AWS_CLOUD"
 
 
-
 @pytest.hookimpl
 def pytest_configure(config: Config):
     config.addinivalue_line("markers", "skip_snapshot_verify")
@@ -69,7 +68,7 @@ def pytest_runtest_call(item: Item) -> None:
         verify = True
         paths = []
 
-        if not is_aws():  # only skip for local tests unless overridden
+        if not is_aws():  # only skip for local tests
             for m in item.iter_markers(name="skip_snapshot_verify"):
                 skip_paths = m.kwargs.get("paths", [])
 

--- a/localstack_snapshot/pytest/snapshot.py
+++ b/localstack_snapshot/pytest/snapshot.py
@@ -20,13 +20,6 @@ def is_aws():
     return os.environ.get("TEST_TARGET", "") == "AWS_CLOUD"
 
 
-def force_skipping_snapshot_verify():
-    """
-    Forces skipping verification according to the snapshot configuration.
-    Useful when is_aws() evaluates to True, but the target is actually an LS instance.
-    """
-    return os.environ.get("TEST_FORCE_SNAPSHOT_SKIP_VERIFY", "") == "1"
-
 
 @pytest.hookimpl
 def pytest_configure(config: Config):
@@ -76,9 +69,7 @@ def pytest_runtest_call(item: Item) -> None:
         verify = True
         paths = []
 
-        if (
-            not is_aws() or force_skipping_snapshot_verify()
-        ):  # only skip for local tests unless overridden
+        if not is_aws():  # only skip for local tests unless overridden
             for m in item.iter_markers(name="skip_snapshot_verify"):
                 skip_paths = m.kwargs.get("paths", [])
 

--- a/localstack_snapshot/pytest/snapshot.py
+++ b/localstack_snapshot/pytest/snapshot.py
@@ -20,6 +20,14 @@ def is_aws():
     return os.environ.get("TEST_TARGET", "") == "AWS_CLOUD"
 
 
+def force_skipping_snapshot_verify():
+    """
+    Forces skipping verification according to the snapshot configuration.
+    Useful when is_aws() evaluates to True, but the target is actually an LS instance.
+    """
+    return os.environ.get("TEST_FORCE_SNAPSHOT_SKIP_VERIFY", "") == "1"
+
+
 @pytest.hookimpl
 def pytest_configure(config: Config):
     config.addinivalue_line("markers", "skip_snapshot_verify")
@@ -68,7 +76,9 @@ def pytest_runtest_call(item: Item) -> None:
         verify = True
         paths = []
 
-        if not is_aws():  # only skip for local tests
+        if (
+            not is_aws() or force_skipping_snapshot_verify()
+        ):  # only skip for local tests unless overridden
             for m in item.iter_markers(name="skip_snapshot_verify"):
                 skip_paths = m.kwargs.get("paths", [])
 


### PR DESCRIPTION
#### Description

This is needed in case of running the LS tests against a non-local version of LS: i.e. an LS instance run on the host, or an instance of LS running in a K8s cluster locally/remotely.