### PR TITLE
fix ResponseMetaDataTransformer

### DIFF
--- a/localstack_snapshot/snapshots/transformer.py
+++ b/localstack_snapshot/snapshots/transformer.py
@@ -102,8 +102,14 @@ class ResponseMetaDataTransformer:
             if k == "ResponseMetadata":
                 metadata = v
                 http_headers = metadata.get("HTTPHeaders")
+                if not isinstance(http_headers, dict):
+                    continue
+
                 # TODO "x-amz-bucket-region"
                 # TestS3.test_region_header_exists -> verifies bucket-region
+
+                # FIXME: proper value is `content-type` with no underscore in lowercase, but this will necessitate a
+                #  refresh of all snapshots
                 headers_to_collect = ["content_type"]
                 simplified_headers = {}
                 for h in headers_to_collect:


### PR DESCRIPTION
While working with API Gateway and trying to snapshot responses coming from AWS_PROXY Integration Subtypes, AWS will return a response containing the `ResponseMetadata` field but already filtered, with no `HTTPHeaders` field in it.

The current `ResponseMetaDataTransformer` will always try access the `HTTPHeaders` field as a dict, even if the value from `http_headers = metadata.get("HTTPHeaders")` is `None`, raising this exception:


```python
                for h in headers_to_collect:
>                   if http_headers.get(h):
E                   AttributeError: 'NoneType' object has no attribute 'get'
../localstack_snapshot/snapshots/transformer.py:110: AttributeError
```

As a workaround, I've implemented a hack like that:
`service_resp["_ResponseMetadata"] = service_resp.pop("ResponseMetadata")`

This PR now properly fixes it, and adds some test for the transformer.

I'd like to note that it seems we were trying to get the `Content-Type` header from the response, but as the value was wrong, it was never captured in any snapshots.
Adding it now would need a full refresh, or a big skip, so this is out of scope of this PR.

For the release version, I'd say this could be a `0.3.1`? 