### PR TITLE
improve reporting suggestion for snapshot skips

### DIFF
--- a/localstack_snapshot/snapshots/report.py
+++ b/localstack_snapshot/snapshots/report.py
@@ -57,7 +57,7 @@ def _format_json_path(path: list):
         if not isinstance(elem, int):
             _elem = str(elem)
             # we want to wrap in single quotes parts with special characters so that users can copy-paste them directly
-            if not _special_json_path_chars_regex.fullmatch(_elem):
+            if not _regular_json_path_chars_regex.fullmatch(_elem):
                 _elem = f"'{_elem}'"
             json_str += _elem
         if idx < len(path) - 1 and not json_str.endswith(".."):

--- a/localstack_snapshot/snapshots/report.py
+++ b/localstack_snapshot/snapshots/report.py
@@ -1,4 +1,5 @@
 import logging
+import re
 
 from localstack_snapshot.snapshots import SnapshotMatchResult
 
@@ -29,6 +30,8 @@ _esctable = {
     "underlined": 4,
 }
 
+_special_json_path_chars_regex = re.compile("[a-zA-Z0-9_-]+")
+
 
 class PatchPath(str):
     """
@@ -52,7 +55,11 @@ def _format_json_path(path: list):
     json_str = "$.."
     for idx, elem in enumerate(path):
         if not isinstance(elem, int):
-            json_str += str(elem)
+            _elem = str(elem)
+            # we want to wrap in single quotes parts with special characters so that users can copy-paste them directly
+            if not _special_json_path_chars_regex.fullmatch(_elem):
+                _elem = f"'{_elem}'"
+            json_str += _elem
         if idx < len(path) - 1 and not json_str.endswith(".."):
             json_str += "."
 

--- a/localstack_snapshot/snapshots/report.py
+++ b/localstack_snapshot/snapshots/report.py
@@ -30,7 +30,7 @@ _esctable = {
     "underlined": 4,
 }
 
-_special_json_path_chars_regex = re.compile("[a-zA-Z0-9_-]+")
+_regular_json_path_chars_regex = re.compile("[a-zA-Z0-9_-]+")
 
 
 class PatchPath(str):

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -209,6 +209,14 @@ def test_json_diff_format():
     assert _format_json_path(path) == '"$.."'
     path = [1, 1, 0, "SomeKey"]
     assert _format_json_path(path) == '"$..SomeKey"'
+    path = ["Some:Key"]
+    assert _format_json_path(path) == "\"$..'Some:Key'\""
+    path = ["Some.Key"]
+    assert _format_json_path(path) == "\"$..'Some.Key'\""
+    path = ["Some-Key"]
+    assert _format_json_path(path) == '"$..Some-Key"'
+    path = ["Some0Key"]
+    assert _format_json_path(path) == '"$..Some0Key"'
 
 
 def test_sorting_transformer():


### PR DESCRIPTION
@pinzon recently shared a trick regarding snapshot skips path that would contain special characters.
It made me remember a fix I had done before this was even its own library with https://github.com/localstack/localstack/pull/6802, allowing us to use single quote in snapshot skip paths for those special characters.

This PR adds better suggestion by detecting and wrapping part elements that would contain such characters so that users could directly copy paste the snapshot skip path and it would work out of the box, instead of having weird issues. 
Luckily there were already tests for the helper function, thanks @dominikschubert 🙏 

For example, for this kind of error which would fail if you copy pasted it to skip that path before, this would be the new message:
```diff
	Ignore list (please keep in mind list indices might not work and should be replaced):
-	["$..cognito:user_status"]
+	["$..'cognito:user_status'"]
```
