### PR TITLE
add custom encoder to persist_state

### DIFF
--- a/localstack_snapshot/snapshots/prototype.py
+++ b/localstack_snapshot/snapshots/prototype.py
@@ -120,7 +120,7 @@ class SnapshotSession:
                         "recorded-content": self.observed_state,
                     }
                     full_state[self.scope_key] = recorded
-                    state_to_dump = json.dumps(full_state, indent=2)
+                    state_to_dump = json.dumps(full_state, indent=2, cls=CustomJsonEncoder)
                     fd.seek(0)
                     fd.truncate()
                     # add line ending to be compatible with pre-commit-hooks (end-of-file-fixer)


### PR DESCRIPTION
### Motivation
I encountered this issue  when writing an EKS/CFn test during a deletion of Stack:
```
Traceback (most recent call last):
  File "/home/cristopher/Work/ls_workspace/localstack-pro/.venv/lib/python3.11/site-packages/localstack_snapshot/snapshots/prototype.py", line 121, in _persist_state
    state_to_dump = json.dumps(full_state, indent=2)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/cristopher/.pyenv/versions/3.11.12/lib/python3.11/json/__init__.py", line 238, in dumps
    **kw).encode(obj)
          ^^^^^^^^^^^
  File "/home/cristopher/.pyenv/versions/3.11.12/lib/python3.11/json/encoder.py", line 202, in encode
    chunks = list(chunks)
             ^^^^^^^^^^^^
  File "/home/cristopher/.pyenv/versions/3.11.12/lib/python3.11/json/encoder.py", line 432, in _iterencode
    yield from _iterencode_dict(o, _current_indent_level)
  File "/home/cristopher/.pyenv/versions/3.11.12/lib/python3.11/json/encoder.py", line 406, in _iterencode_dict
    yield from chunks
  File "/home/cristopher/.pyenv/versions/3.11.12/lib/python3.11/json/encoder.py", line 406, in _iterencode_dict
    yield from chunks
  File "/home/cristopher/.pyenv/versions/3.11.12/lib/python3.11/json/encoder.py", line 406, in _iterencode_dict
    yield from chunks
  [Previous line repeated 2 more times]
  File "/home/cristopher/.pyenv/versions/3.11.12/lib/python3.11/json/encoder.py", line 439, in _iterencode
    o = _default(o)
        ^^^^^^^^^^^
  File "/home/cristopher/.pyenv/versions/3.11.12/lib/python3.11/json/encoder.py", line 180, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type datetime is not JSON serializable
```

So I fixed locally.  Is there a  particular reason the CustomJsonEncoder is not used in `_persis_state`?