### PR TITLE
Fix error message for missing snapshot

### DIFF
--- a/localstack_snapshot/snapshots/prototype.py
+++ b/localstack_snapshot/snapshots/prototype.py
@@ -217,7 +217,7 @@ class SnapshotSession:
 
         if not self.update and (not self.recorded_state or self.recorded_state.get(key) is None):
             raise Exception(
-                f"No state for {self.scope_key} recorded. Please (re-)generate the snapshot for this test."
+                f"No state for {key} recorded. Please (re-)generate the snapshot for this test."
             )
 
         # TODO: we should return something meaningful here


### PR DESCRIPTION
When a key is marked as snapshotted, but not actually present in the `snapshot.json`, the following error is thrown:

> No state for tests/mytest.py recorded. Please (re-)generate the snapshot for this test."

This is very confusing though, as there _is_ a state for `tests/mytest.py` present - it is just missing the state for a specific key.

This PR updates the error message to make it clear that only the `key` is missing, instead of the entire snapshot.