### PR TITLE
Reduce log level for skip_verification_paths from WARNING to DEBUG

### DIFF
--- a/localstack_snapshot/snapshots/prototype.py
+++ b/localstack_snapshot/snapshots/prototype.py
@@ -239,7 +239,7 @@ class SnapshotSession:
 
         self.skip_verification_paths = skip_verification_paths or []
         if skip_verification_paths:
-            SNAPSHOT_LOGGER.warning(
+            SNAPSHOT_LOGGER.debug(
                 "Snapshot verification disabled for paths: %s", skip_verification_paths
             )
 


### PR DESCRIPTION
## Motivation
`_assert_all()` logged at `WARNING` when `skip_verification_paths` was provided, but skipping specific paths is a deliberate and common choice - not an unexpected condition.
This leads to polluted logs in our pipelines.
This PR reduces the log level from `WARNING` to `DEBUG` so it only surfaces when `DEBUG_SNAPSHOT` is set.

## Testing

Both of these scenarios have been tested by me manually locally:
- [x] Confirm no `WARNING` is emitted when skipping specific paths.
- [x] Confirm the message still appears at `DEBUG` level when `DEBUG_SNAPSHOT` is set